### PR TITLE
fix: Return support for Python 3.8

### DIFF
--- a/failure_analysis/failure_analysis.py
+++ b/failure_analysis/failure_analysis.py
@@ -167,7 +167,7 @@ def main():
     parser.add_argument(
         "--drain-off",
         help="Turns drain templating off and will use error text as is. By default drain is enabled.",
-        action=argparse.BooleanOptionalAction,
+        action="store_false",
         default=False,
     )
     parser.add_argument("path", type=str, help="Path to folder where xunit files are stored")


### PR DESCRIPTION
Used argparse in way that was supported only with Python 3.9, returned the older way to also support Python 3.8